### PR TITLE
Replace hard coded biome ids with a tag for easier compatibility

### DIFF
--- a/src/main/resources/data/minecells/tags/worldgen/biome/valid_portal_biomes.json
+++ b/src/main/resources/data/minecells/tags/worldgen/biome/valid_portal_biomes.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:is_forest",
+    "#minecraft:is_taiga",
+    "#byg:is_plains",
+    "minecraft:plains"
+  ]
+}

--- a/src/main/resources/data/minecells/worldgen/structure/portal.json
+++ b/src/main/resources/data/minecells/worldgen/structure/portal.json
@@ -1,12 +1,6 @@
 {
   "type": "minecraft:jigsaw",
-  "biomes": [
-    "minecraft:forest",
-    "minecraft:dark_forest",
-    "minecraft:birch_forest",
-    "minecraft:taiga",
-    "minecraft:plains"
-  ],
+  "biomes": "#minecells:valid_portal_biomes",
   "step": "surface_structures",
   "spawn_overrides": {},
   "terrain_adaptation": "beard_thin",


### PR DESCRIPTION
This changes data\minecells\worldgen\structure\portal.json to accept a tag instead of hard coded biome ids. 
Added a new tag filled with Vanilla's "#minecraft:is_forest", "#minecraft:is_taiga" tags, and also the id for "minecraft:plains" since vanilla doesn't provide a tag for that one. 

And then some mod compatibility for BYG with"#byg:is_plains" tag. BYG and most other biome mods already use the Vanilla biome tags, so the "#minecraft:is_forest", "#minecraft:is_taiga" tags cover the BYG forest and taiga biomes already, but vanilla has no biome tag for plains so that's why this one is here. And since its a tag instead of hardcoded ids, not using BYG won't cause any conflicts.

Doing it this way makes it easy for Minecells to add modded biome compatibility, or for pack makers to simply add more biomes to the "#minecells:valid_portal_biomes" tag.