### PR TITLE
Fix isChunkLoaded check

### DIFF
--- a/src/main/java/com/github/mim1q/minecells/mixin/world/WorldMixin.java
+++ b/src/main/java/com/github/mim1q/minecells/mixin/world/WorldMixin.java
@@ -2,6 +2,7 @@ package com.github.mim1q.minecells.mixin.world;
 
 import net.minecraft.block.Block;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkSectionPos;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public abstract class WorldMixin implements WorldAccess, AutoCloseable {
   @Inject(method = "updateComparators", at = @At("HEAD"), cancellable = true)
   private void minecells$cancelUpdateComparators(BlockPos pos, Block block, CallbackInfo ci) {
-    if (!this.isChunkLoaded(pos.getX(), pos.getZ())) {
+    if (!this.isChunkLoaded(ChunkSectionPos.getSectionCoord(pos.getX()), ChunkSectionPos.getSectionCoord(pos.getZ()))) {
       ci.cancel();
     }
   }


### PR DESCRIPTION
This will fix comparators being completely broken, but this mixin looks like a hack in general, it will still break some redstone contraptions even when using the correct coordinates.

Fixes #36, but really whatever issue this mixin is trying to fix should be properly addressed instead, to avoid edge cases where it will break things.